### PR TITLE
Point commented code to use the IExistence interface

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -8,13 +8,11 @@ namespace Ideal
         {
             // Change this line to instantiate another existence:
             //IExistence existence = new Existence010();
-            //Existence existence = new Existence020();
-            //Existence existence = new Existence030();
-            //Existence existence = new Existence031();
-            //Existence existence = new Existence032();
+            //IExistence existence = new Existence020();
+            //IExistence existence = new Existence030();
+            //IExistence existence = new Existence031();
+            //IExistence existence = new Existence032();
             IExistence existence = new Existence040();
-            //Existence existence = new Existence050();
-            //Existence existence = new Existence051();
 
             // Change this line to adjust the number of cycles of the loop:
             for (int i = 0; i < 20; i++)


### PR DESCRIPTION
As Program.cs contained all branch code to start the program, change previous branch commented code to use IExistence where the user can simply uncomment a line and use the feature from that branch.

Also removed features from forward branches that are not in this code base. For example, branch-05.